### PR TITLE
docs: Update documentation hyperlinks in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Expo is an open-source platform for making universal native apps that run on And
 
 <p>Learn about building and deploying universal apps <a aria-label="expo documentation" href="https://docs.expo.io">in our official docs!</a></p>
 
-- [Getting Started](https://docs.expo.io/versions/latest/)
-- [API Reference](https://docs.expo.io/versions/latest/sdk/overview/)
-- [Using Custom Native Modules](https://docs.expo.io/versions/latest/bare/exploring-bare-workflow/)
+- [Getting Started](https://docs.expo.io/)
+- [API Reference](https://docs.expo.io/versions/latest/)
+- [Using Custom Native Modules](https://docs.expo.io/bare/exploring-bare-workflow/)
 
 ## 🗺 Project Layout
 


### PR DESCRIPTION
Updated outdated hyperlinks in project readme file

# Why
Addresses https://github.com/expo/expo/issues/9484

# How
Onboarding to documentation using the readme results in confusion

# Test Plan
Tested links in preview of readme in local repo.